### PR TITLE
Corrected serialisation of Z1 and Z2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,11 +181,11 @@ function uncompressG1(compressedValue: bigint) {
 }
 
 function compressG2(point: Point<[bigint, bigint]>) {
+  if (point.equals(Z2)) {
+    return [POW_2_383 + POW_2_382, 0n];
+  }
   if (!point.isOnCurve(B2)) {
     throw new Error("The given point is not on the twisted curve over FQ**2");
-  }
-  if (point.isEmpty()) {
-    return [POW_2_383 + POW_2_382, 0n];
   }
   const [[x0, x1], [y0, y1]] = point.to2D().map(a => a.value);
   const producer = y1 > 0 ? y1 : y0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,7 +152,7 @@ export async function getXCoordinate(hash: Hash, domain: Bytes) {
 const POW_SUM = POW_2_383 + POW_2_382;
 
 function compressG1(point: Point<bigint>) {
-  if (point.isEmpty()) {
+  if (point.equals(Z1)) {
     return POW_SUM;
   }
   const [x, y] = point.to2D() as [Fp, Fp];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -280,7 +280,7 @@ describe("bls12-381", () => {
       { numRuns: NUM_RUNS }
     );
   });
-  it("should create right public key for point at infinity", async () => {
+  it("should create right public key for private key 0", async () => {
     const publicKey = await bls.getPublicKey(0n);
     expect(Buffer.from(publicKey).toString("hex")).toBe(
       "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -381,6 +381,12 @@ describe("bls12-381", () => {
     ]);
     expect(Buffer.from(aggregatedPublicKey).toString("hex")).toBe(
       "aa1554bee817c20ac1ae3abd55da26bef2b51299201f1328c73ddab130d943a27ef9330b502c54012079d9bd641f8bfd"
+    );
+  });
+  it("should create right signature for private key 0", async () => {
+    const signature = await bls.sign("00", 0n, 1);
+    expect(Buffer.from(signature).toString("hex")).toBe(
+      "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     );
   });
   it("should create right signature for vector 1", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -280,6 +280,12 @@ describe("bls12-381", () => {
       { numRuns: NUM_RUNS }
     );
   });
+  it("should create right public key for point at infinity", async () => {
+    const publicKey = await bls.getPublicKey(0n);
+    expect(Buffer.from(publicKey).toString("hex")).toBe(
+      "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    );
+  });
   it("should create right public key for vector 1", async () => {
     const publicKey = await bls.getPublicKey(15n);
     expect(Buffer.from(publicKey).toString("hex")).toBe(


### PR DESCRIPTION
Hi @paulmillr,

Here are two small fixes for `compressG1()` and `compressG2()`. I'm not sure if the `isEmpty()` function is meant to imply that a point is the point at infinity, but I found if I modified that it broke other tests.

Let me know what you think.

Mark