### PR TITLE
[point multiplication] - Allow points to multiply by a zero scalar.

### DIFF
--- a/math.js
+++ b/math.js
@@ -814,7 +814,7 @@ class ProjectivePoint {
             n = n.value;
         if (typeof n === 'number')
             n = BigInt(n);
-        if (n <= 0) {
+        if (n < 0) {
             throw new Error('Point#multiply: invalid scalar, expected positive integer');
         }
         let p = this.getZero();
@@ -829,7 +829,7 @@ class ProjectivePoint {
     }
     multiply(scalar) {
         let n = scalar;
-        if (typeof n !== 'bigint' || n <= 0) {
+        if (typeof n !== 'bigint' || n < 0) {
             throw new Error('Point#multiply: invalid scalar, expected positive integer');
         }
         let p = this.getZero();

--- a/math.ts
+++ b/math.ts
@@ -1009,7 +1009,7 @@ export abstract class ProjectivePoint<T extends Field<T>> {
     let n = scalar;
     if (n instanceof Fq) n = n.value;
     if (typeof n === 'number') n = BigInt(n);
-    if (n <= 0) {
+    if (n < 0) {
       throw new Error('Point#multiply: invalid scalar, expected positive integer');
     }
     let p = this.getZero();
@@ -1025,7 +1025,7 @@ export abstract class ProjectivePoint<T extends Field<T>> {
   // Constant-time multiplication
   multiply(scalar: bigint): this {
     let n = scalar;
-    if (typeof n !== 'bigint' || n <= 0) {
+    if (typeof n !== 'bigint' || n < 0) {
       throw new Error('Point#multiply: invalid scalar, expected positive integer');
     }
     let p = this.getZero();

--- a/test/point.test.ts
+++ b/test/point.test.ts
@@ -472,4 +472,8 @@ describe('bls12-381 Point', () => {
       expect(p.multiplyUnsafe(CURVE.h_eff).equals(clearCofactorG2(p))).toEqual(true);
     }
   });
+  it('Allow point multiplication by zero.', () => {
+    expect(PointG1.BASE.multiply(0n)).toEqual(PointG1.ZERO);
+    expect(PointG2.BASE.multiply(0n)).toEqual(PointG2.ZERO)
+  });
 });


### PR DESCRIPTION
Points can multiply by a zero scalar.

At the Tezos blockchain, a group found this issue when implementing a smart contract for [zkchannels](https://github.com/boltlabs-inc/libzkchannels/blob/master/tezos-sandbox/tests_python/zkchannels_contract/zkchannel_smartpy_script.py). Where multiplying a given G1/G2 by Fr(0) would throw `Point#multiply: invalid scalar, expected positive integer` but the operation is valid.