### PR TITLE
Adds compressed serialization for G2 points

### DIFF
--- a/math.ts
+++ b/math.ts
@@ -83,7 +83,7 @@ export function mod(a: bigint, b: bigint) {
 }
 
 /**
- * Efficiently expotentiate num to power and do modular division.
+ * Efficiently exponentiate num to power and do modular division.
  * @example
  * powMod(2n, 6n, 11n) // 64n % 11n == 9n
  */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -250,6 +250,15 @@ describe('bls12-381', () => {
   it('should not compress and decompress zero G1 point', async () => {
     expect(() => bls.PointG1.fromPrivateKey(0n)).toThrowError();
   });
+  it('should compress and decompress G2 points', async () => {
+    const priv = bls.PointG2.fromPrivateKey(42n);
+    const publicKey = priv.toHex(true);
+    const decomp = bls.PointG2.fromHex(publicKey);
+    expect(publicKey).toEqual(decomp.toHex(true));
+  });
+  it('should not compress and decompress zero G2 point', async () => {
+    expect(() => bls.PointG2.fromPrivateKey(0n)).toThrowError();
+  });
   const VALID_G1 = new bls.PointG1(
     new bls.Fp(
       3609742242174788176010452839163620388872641749536604986743596621604118973777515189035770461528205168143692110933639n


### PR DESCRIPTION
Adds compressed serialization for G2 points. I tried to copy the style of the G1 compressed serialization, but borrowed more from [Appendix C of the pairing-friendly curves draft](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#appendix-C).

If this is desirable, I can continue work on this PR to harmonize the G1 and G2 code for this.

Context: using this library for a BBS+ implementation.